### PR TITLE
Use PHP_EOL for newlines.

### DIFF
--- a/src/BStrapElement.php
+++ b/src/BStrapElement.php
@@ -67,7 +67,7 @@ abstract class BStrapElement
         if ($this->class != null)
           $html .= ' '.$this->class.'">';
         else
-          $html .= '">';
+          $html .= '">' . PHP_EOL;
 
         return $html;
     }
@@ -80,7 +80,7 @@ abstract class BStrapElement
         if ($this->tag == null)
             $html  = '</div>';
         else
-            $html  = '</'.$this->tag.'>';
+            $html  = '</'.$this->tag.'>' . PHP_EOL;
 
         return $html;
     }

--- a/src/Html.php
+++ b/src/Html.php
@@ -26,14 +26,14 @@ class Html
             }
         }
 
-        $markup .= '>';
+        $markup .= '>' . PHP_EOL;
 
         if(is_string($spec))
             $markup .= $spec;
         else if (array_key_exists('text', $spec))
             $markup .= $spec['text'];
 
-        $markup .= "</".$description['tag'].">\n";
+        $markup .= "</".$description['tag'].">" . PHP_EOL;
 
         return $markup;
     }
@@ -192,7 +192,7 @@ class Html
         if (array_key_exists('class', $spec))
             $markup .= ' class="'.$spec['class'].'"';
 
-        $markup .= '>';
+        $markup .= '>' . PHP_EOL;
 
         if (array_key_exists('elements', $spec))
             if (is_array($spec['elements']))
@@ -201,7 +201,7 @@ class Html
                 $markup .= $spec['elements'];
 
 
-        $markup .= "</$type>";
+        $markup .= "</$type>" .PHP_EOL;
 
         return $markup;
     }
@@ -240,7 +240,7 @@ class Html
                 $markup .= "<th>$attribute</th>";
             }
 
-            $markup .= "</tr>\n";
+            $markup .= "</tr>" . PHP_EOL;
         }
 
         foreach ($spec['rows'] as $row) {
@@ -250,9 +250,9 @@ class Html
             $markup .= "<td>$data</td>";
           }
 
-          $markup .= "</tr>\n";
+          $markup .= "</tr>" . PHP_EOL;
         }
 
-        return $markup .= "</table>\n";
+        return $markup .= "</table>" . PHP_EOL;
     }
 }


### PR DESCRIPTION
PHP_EOL will decide the correct character to use on each system. Add
newlines to HTML elements so that the generated source code is more
readable.